### PR TITLE
Using count to check the $attributes is not empty

### DIFF
--- a/src/Tag.php
+++ b/src/Tag.php
@@ -75,7 +75,7 @@ class Tag
         $this->name   = $name;
         $this->isVoid = in_array($name, self::VOID_ELEMENTS, true);
 
-        if ($attributes) {
+        if (count($attributes) !== 0) {
             $this->setAttributes($attributes);
         }
     }


### PR DESCRIPTION
# Changed log
- Using `count` function to check the `$attributes` array length is not empty.
It will be more readable than original approach.